### PR TITLE
Gave the templates a dark solarized color theme

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -8,39 +8,68 @@
 <meta name="version" content="<?=$version;?>">
 
 <style type="text/css">
-html body {
+* {
+	box-sizing: border-box;
+}
+
+body {
+	padding-top: 6em;
+	background-color: #002B36;
+	color: #93A1A1;
 	font-family: Arial,Helvetica,sans-serif;
-	font-size: 12px;
 }
 
-#container {
-	width:500px;
-	margin:0 auto;
-	margin-top:150px;
+a {
+	color: #93A1A1;
 }
 
-#error {
-	color:red;
-	font-weight:bold;
+.url:focus,
+.url:active,
+.go:focus,
+.go:active {
+	outline: none;
 }
 
-#frm {
-	padding:10px 15px;
-	background-color:#FFC8C8;
-	
-	border:1px solid #818181;
-	
-	-webkit-border-radius: 8px;
-	-moz-border-radius: 8px;
-	border-radius: 8px;
+.url {
+	width: 88%;
+	margin-right: 2%;
+	background-color: #FDF6E3;
+	color: #657B83;
 }
 
-#footer {
-	text-align:center;
-	font-size:10px;
-	margin-top:35px;
-	clear:both;
+.go {
+	width: 10%;
+	background-color: #2AA198;
+	color: #FDF6E3;
+	cursor: pointer;
 }
+
+.url,
+.go {
+	display: block;
+	padding: .5em;
+	float: left;
+	border: none;
+	font-size: 14px;
+}
+
+.container {
+	padding: 1em;
+	margin: 1em auto;
+	width: 36em;
+	background-color: #073642;
+}
+
+.container:after {
+	display: table;
+	content: '';
+	clear: both;
+}
+
+.footer {
+	text-align: center;
+}
+
 </style>
 
 </head>
@@ -48,10 +77,10 @@ html body {
 <body>
 
 
-<div id="container">
+<div class="container">
 
 	<div style="text-align:center;">
-		<h1 style="color:blue;">PHP-Proxy</h1>
+		<h1>PHP-Proxy</h1>
 	</div>
 	
 	<?php if(isset($error_msg)){ ?>
@@ -66,9 +95,9 @@ html body {
 	
 	<!-- I wouldn't touch this part -->
 	
-		<form action="index.php" method="post" style="margin-bottom:0;">
-			<input name="url" type="text" style="width:400px;" autocomplete="off" placeholder="http://" />
-			<input type="submit" value="Go" />
+		<form action="index.php" method="post">
+			<input class="url" name="url" type="text" autocomplete="off" placeholder="http://" />
+			<input class="go" type="submit" value="Go" />
 		</form>
 		
 		<script type="text/javascript">
@@ -81,7 +110,7 @@ html body {
 	
 </div>
 
-<div id="footer">
+<div class="footer">
 	Powered by <a href="//www.php-proxy.com/" target="_blank">PHP-Proxy</a> <?php echo $version; ?>
 </div>
 

--- a/templates/url_form.php
+++ b/templates/url_form.php
@@ -5,7 +5,7 @@ html body {
 	margin-top: 50px !important;
 }
 
-#top_form {
+#php-proxy-bar {
 	position: fixed;
 	top:0;
 	left:0;
@@ -21,19 +21,68 @@ html body {
 	
 	border-bottom:1px solid #151515;
 	
-    background:#FFC8C8;
+    background:#073642;
 	
-	height:45px;
-	line-height:45px;
+	height:46px;
+	line-height:46px;
 }
 
-#top_form input[name=url] {
-	width: 550px;
-	height: 20px;
-	padding: 5px;
-	font: 13px "Helvetica Neue",Helvetica,Arial,sans-serif;
-	border: 0px none;
-	background: none repeat scroll 0% 0% #FFF;
+#php-proxy-form {
+	width: 800px;
+	margin: 8px auto 0;
+}
+
+#php-proxy-home {
+	margin: 0 2% 0 0;
+	background-color: #586E75;
+	color: #FDF6E3;
+	font-size: 24px;
+}
+
+#php-proxy-url {
+	margin: 0 2% 0 0;
+	width: 74%;
+	background-color: #FDF6E3;
+	color: #657B83;
+}
+
+#php-proxy-url:focus,
+#php-proxy-url:active,
+#php-proxy-go:focus,
+#php-proxy-go:active,
+#php-proxy-home:focus,
+#php-proxy-home:active {
+	outline: none;
+}
+
+#php-proxy-go {
+	margin: 0;
+	background-color: #2AA198;
+	background-image: none;
+	color: #FDF6E3;
+	line-height: normal;
+}
+
+#php-proxy-home,
+#php-proxy-go {
+	width: 10%;
+	text-align: center;
+	text-shadow: none;
+	cursor: pointer;
+}
+
+#php-proxy-home,
+#php-proxy-url,
+#php-proxy-go {
+	box-sizing: border-box;
+	display: block;
+	float: left;
+	padding: .5em;
+	height: 30px;
+	font-size: 14px;
+	border: none;
+	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+	border-radius: 0;
 }
 
 </style>
@@ -57,19 +106,14 @@ function smart_select(ele){
 }
 </script>
 
-<div id="top_form">
-
-	<div style="width:800px; margin:0 auto;">
-	
-		<form method="post" action="index.php" target="_top" style="margin:0; padding:0;">
-			<input type="button" value="Home" onclick="window.location.href='index.php'">
-			<input type="text" name="url" value="<?php echo $url; ?>" autocomplete="off">
-			<input type="hidden" name="form" value="1">
-			<input type="submit" value="Go">
-		</form>
+<div id="php-proxy-bar">
+	<form id="php-proxy-form" method="post" action="index.php" target="_top">
+		<input id="php-proxy-home" type="button" value="Home" onclick="window.location.href='index.php'" />
+		<input id="php-proxy-url" type="text" name="url" value="<?php echo $url; ?>" autocomplete="off">
 		
-	</div>
-	
+		<input type="hidden" name="form" value="1">
+		<input id="php-proxy-go" type="submit" value="Go" />
+	</form>
 </div>
 
 <script type="text/javascript">


### PR DESCRIPTION
Here's a look at what these changes do:

<img width="826" alt="screen shot 2017-02-06 at 5 19 28 pm" src="https://cloud.githubusercontent.com/assets/8248986/22692093/5d559478-ed0b-11e6-9a0d-3ef0135221e7.png">

<img width="857" alt="screen shot 2017-02-07 at 8 00 08 am" src="https://cloud.githubusercontent.com/assets/8248986/22692123/83d7254e-ed0b-11e6-8282-f3612c4f0fb2.png">

I've added some of the most common css rules needed to override web page styles that make the url form look wrong.  More can be added easily.

I also switched to a more common css practice in the main page, using class instead of id for selectors.  But on the url form I kept it id selectors in order to keep the highest specificity.  I also prefixed the id to even more decrease the chance of their styles getting overridden